### PR TITLE
Added pipes.quote function to escape shell commands

### DIFF
--- a/steg_brute.py
+++ b/steg_brute.py
@@ -5,6 +5,7 @@ from progressbar import ProgressBar, Percentage, Bar
 from argparse import ArgumentParser
 import commands
 import os
+from pipes import quote
 
 
 class color:
@@ -51,7 +52,7 @@ def Steg_brute(ifile, dicc):
         pbar = ProgressBar(widgets=[Percentage(), Bar()], maxval=nlines).start()
         for line in passFile.readlines():
             password = line.strip('\n')
-            r = commands.getoutput("steghide extract -sf %s -p '%s' -xf %s" % (ifile, password, ofile))
+            r = commands.getoutput("steghide extract -sf %s -p %s -xf %s" % (ifile, quote(password), ofile))
             if not "no pude extraer" in r and not "could not extract" in r:
                 print(color.GREEN + "\n\n " + r + color.ENDC)
                 print("\n\n [+] " + color.INFO + "Information obtained with password:" + color.GREEN + " %s\n" % password + color.ENDC)
@@ -66,7 +67,7 @@ def Steg_brute(ifile, dicc):
 
 def steghide(ifile, passwd):
     ofile = ifile.split('.')[0] + "_flag.txt"
-    r = commands.getoutput("steghide extract -sf %s -p '%s' -xf %s" % (ifile, passwd, ofile))
+    r = commands.getoutput("steghide extract -sf %s -p %s -xf %s" % (ifile, quote(passwd), ofile))
     if not "no pude extraer" in r and not "could not extract" in r:
         print(color.GREEN + "\n\n " + r + color.ENDC)
         print("\n [+] " + color.INFO + "Information obtained: \n" + color.ENDC)

--- a/steg_brute.py
+++ b/steg_brute.py
@@ -24,7 +24,7 @@ def check_file(file):
         return False
 
     
-VERSION = "1.0"
+VERSION = "1.1"
 
 SAMPLES = """
 Type ./steg_brute.py -h to show help


### PR DESCRIPTION
This way we avoid unterminated quoted string error on commands.getoutput
call.
Fix #3, Close #4 
  